### PR TITLE
Command Key Making Correction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/canhlinh/gozk
+module github.com/nokibsarkar/gozk
 
 require (
 	github.com/canhlinh/go-binary-pack v0.0.0-20181203110405-72348cf47f32

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nokibsarkar/gozk
+module github.com/canhlinh/gozk
 
 require (
 	github.com/canhlinh/go-binary-pack v0.0.0-20181203110405-72348cf47f32

--- a/util.go
+++ b/util.go
@@ -163,7 +163,7 @@ func makeCommKey(key, sessionID int, ticks int) ([]byte, error) {
 	})
 
 	unpack = mustUnpack([]string{"H", "H"}, pack)
-	pack, _ = newBP().Pack([]string{"H", "H"}, []interface{}{unpack[0], unpack[1]})
+	pack, _ = newBP().Pack([]string{"H", "H"}, []interface{}{unpack[1], unpack[0]})
 
 	b := 0xff & ticks
 	unpack = mustUnpack([]string{"B", "B", "B", "B"}, pack)


### PR DESCRIPTION
For some reason, it was not working with my Zkteco-A50. So, I, following [this thingy](https://github.com/fananimi/pyzk/blob/50637985b56c3312bf80346c022ebfa567e02808/zk/base.py#L47), swapped the bytes and now the library is working properly. It fixes #12 